### PR TITLE
Remove redundant </div>

### DIFF
--- a/match_and_split/match_and_split.py
+++ b/match_and_split/match_and_split.py
@@ -315,7 +315,7 @@ def do_split(mysite, rootname, user, codelang):
 
         else:
             header = u'<noinclude><pagequality level="1" user="Phe-bot" />\n\n\n</noinclude>'
-            footer = u'<noinclude>\n<references/></div></noinclude>'
+            footer = u'<noinclude>\n<references/></noinclude>'
             content = header + content + footer
             
 


### PR DESCRIPTION
Opening div was removed in de1a8c9f6607a4d95f8ef0677adfd19440aad2b2. This removes closing div as well. Fix #13.